### PR TITLE
Added hashmap and updated BRSet

### DIFF
--- a/BRSet.c
+++ b/BRSet.c
@@ -26,22 +26,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
-
-// linear probed hashtable for good cache performance, maximum load factor is 2/3
-
-static const size_t tableSizes[] = { // starting with 1, multiply by 3/2, round up, then find next largest prime
-    1, 3, 7, 13, 23, 37, 59, 97, 149, 227, 347, 523, 787, 1187, 1783, 2677, 4019, 6037, 9059, 13591,
-    20389, 30593, 45887, 68863, 103307, 154981, 232487, 348739, 523129, 784697, 1177067, 1765609,
-    2648419, 3972643, 5958971, 8938469, 13407707, 20111563, 30167359, 45251077, 67876637, 101814991,
-    152722489, 229083739, 343625629, 515438447, 773157683, 1159736527, 1739604799, 2609407319, 3914111041
-};
-
-#define TABLE_SIZES_LEN (sizeof(tableSizes)/sizeof(*tableSizes))
+#include <hashmap.h>
+#include <math.h>
 
 struct BRSetStruct {
-    void **table; // hashtable
-    size_t size; // number of buckets in table
-    size_t itemCount; // number of items in set
+    map_t **map; // map of item has to position
     size_t (*hash)(const void *); // hash function
     int (*eq)(const void *, const void *); // equality function
 };
@@ -53,17 +42,7 @@ static void _BRSetInit(BRSet *set, size_t (*hash)(const void *), int (*eq)(const
     assert(eq != NULL);
     assert(capacity >= 0);
 
-    size_t i = 0;
-    
-    while (i < TABLE_SIZES_LEN && tableSizes[i] < capacity) i++;
-
-    if (i + 1 < TABLE_SIZES_LEN) { // use next larger table size to keep load factor below 2/3 at capacity
-        set->table = calloc(tableSizes[i + 1], sizeof(void *));
-        assert(set->table != NULL);
-        set->size = tableSizes[i + 1];
-    }
-    
-    set->itemCount = 0;
+    set->map = hashmap_new();
     set->hash = hash;
     set->eq = eq;
 }
@@ -76,23 +55,10 @@ static void _BRSetInit(BRSet *set, size_t (*hash)(const void *), int (*eq)(const
 BRSet *BRSetNew(size_t (*hash)(const void *), int (*eq)(const void *, const void *), size_t capacity)
 {
     BRSet *set = calloc(1, sizeof(*set));
-    
+
     assert(set != NULL);
     _BRSetInit(set, hash, eq, capacity);
     return set;
-}
-
-// rebuilds hashtable to hold up to capacity items
-static void _BRSetGrow(BRSet *set, size_t capacity)
-{
-    BRSet newSet;
-    
-    _BRSetInit(&newSet, set->hash, set->eq, capacity);
-    BRSetUnion(&newSet, set);
-    free(set->table);
-    set->table = newSet.table;
-    set->size = newSet.size;
-    set->itemCount = newSet.itemCount;
 }
 
 // adds given item to set or replaces an equivalent existing item and returns item replaced if any
@@ -100,19 +66,10 @@ void *BRSetAdd(BRSet *set, void *item)
 {
     assert(set != NULL);
     assert(item != NULL);
-    
-    size_t size = set->size;
-    size_t i = set->hash(item) % size;
-    void *t = set->table[i];
 
-    while (t && t != item && ! set->eq(t, item)) { // probe for empty bucket
-        i = (i + 1) % size;
-        t = set->table[i];
-    }
-
-    if (! t) set->itemCount++;
-    set->table[i] = item;
-    if (set->itemCount > ((size + 2)/3)*2) _BRSetGrow(set, size); // limit load factor to 2/3
+    size_t hash = set->hash(item);
+    void *t = hashmap_get(set->map, hash);
+    hashmap_put(set->map, hash, item);
     return t;
 }
 
@@ -121,31 +78,10 @@ void *BRSetRemove(BRSet *set, const void *item)
 {
     assert(set != NULL);
     assert(item != NULL);
-    
-    size_t size = set->size;
-    size_t i = set->hash(item) % size;
-    void *r = set->table[i], *t;
 
-    while (r != item && r && ! set->eq(r, item)) { // probe for item
-        i = (i + 1) % size;
-        r = set->table[i];
-    }
-    
-    if (r) {
-        set->itemCount--;
-        set->table[i] = NULL;
-        i = (i + 1) % size;
-        t = set->table[i];
-        
-        while (t) { // hashtable cleanup
-            set->itemCount--;
-            set->table[i] = NULL;
-            BRSetAdd(set, t);
-            i = (i + 1) % size;
-            t = set->table[i];
-        }
-    }
-    
+    size_t hash = set->hash(item);
+    void *r = hashmap_get(set->map, hash);
+    hashmap_remove(set->map, hash);
     return r;
 }
 
@@ -153,17 +89,15 @@ void *BRSetRemove(BRSet *set, const void *item)
 void BRSetClear(BRSet *set)
 {
     assert(set != NULL);
-    
-    memset(set->table, 0, set->size*sizeof(*set->table));
-    set->itemCount = 0;
+    hashmap_clear(set->map);
 }
 
 // returns the number of items in set
 size_t BRSetCount(const BRSet *set)
 {
     assert(set != NULL);
-    
-    return set->itemCount;
+
+    return hashmap_length(set->map);
 }
 
 // true if an item equivalant to the given item is contained in set
@@ -172,82 +106,15 @@ int BRSetContains(const BRSet *set, const void *item)
     return (BRSetGet(set, item) != NULL);
 }
 
-// true if any items in otherSet are contained in set
-int BRSetIntersects(const BRSet *set, const BRSet *otherSet)
-{
-    assert(set != NULL);
-    assert(otherSet != NULL);
-    
-    size_t i = 0, size = otherSet->size;
-    void *t;
-    
-    while (i < size) {
-        t = otherSet->table[i++];
-        if (t && BRSetGet(set, t) != NULL) return 1;
-    }
-    
-    return 0;
-}
-
 // returns member item from set equivalent to given item, or NULL if there is none
 void *BRSetGet(const BRSet *set, const void *item)
 {
     assert(set != NULL);
     assert(item != NULL);
-    
-    size_t size = set->size;
-    size_t i = set->hash(item) % size;
-    void *t = set->table[i];
 
-    while (t != item && t && ! set->eq(t, item)) { // probe for item
-        i = (i + 1) % size;
-        t = set->table[i];
-    }
-    
+    size_t hash = set->hash(item);
+    size_t *t = hashmap_get(set->map, hash);
     return t;
-}
-
-// interates over set and returns the next item after previous, or NULL if no more items are available
-// if previous is NULL, an initial item is returned
-void *BRSetIterate(const BRSet *set, const void *previous)
-{
-    assert(set != NULL);
-    
-    size_t i = 0, size = set->size;
-    void *t, *r = NULL;
-    
-    if (previous != NULL) {
-        i = set->hash(previous) % size;
-        t = set->table[i];
-        
-        while (t != previous && t && ! set->eq(t, previous)) { // probe for item
-            i = (i + 1) % size;
-            t = set->table[i];
-        }
-    
-        i++;
-    }
-    
-    while (! r && i < size) r = set->table[i++];
-    return r;
-}
-
-// writes up to count items from set to allItems and returns the number of items written
-size_t BRSetAll(const BRSet *set, void *allItems[], size_t count)
-{
-    assert(set != NULL);
-    assert(allItems != NULL || count == 0);
-    assert(count >= 0);
-    
-    size_t i = 0, j = 0, size = set->size;
-    void *t;
-    
-    while (i < size && j < count) {
-        t = set->table[i++];
-        if (t) allItems[j++] = t;
-    }
-    
-    return j;
 }
 
 // calls apply() with each item in set
@@ -255,62 +122,12 @@ void BRSetApply(const BRSet *set, void *info, void (*apply)(void *info, void *it
 {
     assert(set != NULL);
     assert(apply != NULL);
-    
-    size_t i = 0, size = set->size;
-    void *t;
-    
+
+    size_t i = 0, size = hashmap_length(set->map);
+
     while (i < size) {
-        t = set->table[i++];
+        void *t = hashmap_get_index(set->map, i++);
         if (t) apply(info, t);
-    }
-}
-
-// adds or replaces items from otherSet into set
-void BRSetUnion(BRSet *set, const BRSet *otherSet)
-{
-    assert(set != NULL);
-    assert(otherSet != NULL);
-    
-    size_t i = 0, size = otherSet->size;
-    void *t;
-    
-    while (i < size) {
-        t = otherSet->table[i++];
-        if (t) BRSetAdd(set, t);
-    }
-}
-
-// removes items contained in otherSet from set
-void BRSetMinus(BRSet *set, const BRSet *otherSet)
-{
-    assert(set != NULL);
-    assert(otherSet != NULL);
-
-    size_t i = 0, size = otherSet->size;
-    void *t;
-    
-    while (i < size) {
-        t = otherSet->table[i++];
-        if (t) BRSetRemove(set, t);
-    }
-}
-
-// removes items not contained in otherSet from set
-void BRSetIntersect(BRSet *set, const BRSet *otherSet)
-{
-    assert(set != NULL);
-    assert(otherSet != NULL);
-
-    size_t i = 0, size = set->size;
-    void *t;
-    
-    while (i < size) {
-        t = set->table[i];
-
-        if (t && ! BRSetContains(otherSet, t)) {
-            BRSetRemove(set, t);
-        }
-        else i++;
     }
 }
 
@@ -318,7 +135,6 @@ void BRSetIntersect(BRSet *set, const BRSet *otherSet)
 void BRSetFree(BRSet *set)
 {
     assert(set != NULL);
-
-    free(set->table);
+    hashmap_free(set->map);
     free(set);
 }

--- a/BRSet.c
+++ b/BRSet.c
@@ -124,9 +124,10 @@ void BRSetApply(const BRSet *set, void *info, void (*apply)(void *info, void *it
     assert(apply != NULL);
 
     size_t i = 0, size = hashmap_length(set->map);
-
+    void *t;
+    
     while (i < size) {
-        void *t = hashmap_get_index(set->map, i++);
+        t = hashmap_get_index(set->map, i++);
         if (t) apply(info, t);
     }
 }

--- a/hashmap.c
+++ b/hashmap.c
@@ -1,0 +1,399 @@
+/*
+ * Generic map implementation.
+ */
+#include "hashmap.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#define INITIAL_SIZE (256)
+#define MAX_CHAIN_LENGTH (8)
+
+/* We need to keep keys and values */
+typedef struct _hashmap_element{
+    size_t key;
+    int in_use;
+    any_t data;
+} hashmap_element;
+
+/* A hashmap has some maximum size and current size,
+ * as well as the data to hold. */
+typedef struct _hashmap_map{
+    int table_size;
+    int size;
+    hashmap_element *data;
+} hashmap_map;
+
+/*
+ * Return an empty hashmap, or NULL on failure.
+ */
+map_t hashmap_new() {
+    hashmap_map* m = (hashmap_map*) malloc(sizeof(hashmap_map));
+    if(!m) goto err;
+
+    m->data = (hashmap_element*) calloc(INITIAL_SIZE, sizeof(hashmap_element));
+    if(!m->data) goto err;
+
+    m->table_size = INITIAL_SIZE;
+    m->size = 0;
+
+    return m;
+    err:
+    if (m)
+        hashmap_free(m);
+    return NULL;
+}
+
+/* The implementation here was originally done by Gary S. Brown.  I have
+   borrowed the tables directly, and made some minor changes to the
+   crc32-function (including changing the interface). //ylo */
+
+/* ============================================================= */
+/*  COPYRIGHT (C) 1986 Gary S. Brown.  You may use this program, or       */
+/*  code or tables extracted from it, as desired without restriction.     */
+/*                                                                        */
+/*  First, the polynomial itself and its table of feedback terms.  The    */
+/*  polynomial is                                                         */
+/*  X^32+X^26+X^23+X^22+X^16+X^12+X^11+X^10+X^8+X^7+X^5+X^4+X^2+X^1+X^0   */
+/*                                                                        */
+/*  Note that we take it "backwards" and put the highest-order term in    */
+/*  the lowest-order bit.  The X^32 term is "implied"; the LSB is the     */
+/*  X^31 term, etc.  The X^0 term (usually shown as "+1") results in      */
+/*  the MSB being 1.                                                      */
+/*                                                                        */
+/*  Note that the usual hardware shift register implementation, which     */
+/*  is what we're using (we're merely optimizing it by doing eight-bit    */
+/*  chunks at a time) shifts bits into the lowest-order term.  In our     */
+/*  implementation, that means shifting towards the right.  Why do we     */
+/*  do it this way?  Because the calculated CRC must be transmitted in    */
+/*  order from highest-order term to lowest-order term.  UARTs transmit   */
+/*  characters in order from LSB to MSB.  By storing the CRC this way,    */
+/*  we hand it to the UART in the order low-byte to high-byte; the UART   */
+/*  sends each low-bit to hight-bit; and the result is transmission bit   */
+/*  by bit from highest- to lowest-order term without requiring any bit   */
+/*  shuffling on our part.  Reception works similarly.                    */
+/*                                                                        */
+/*  The feedback terms table consists of 256, 32-bit entries.  Notes:     */
+/*                                                                        */
+/*      The table can be generated at runtime if desired; code to do so   */
+/*      is shown later.  It might not be obvious, but the feedback        */
+/*      terms simply represent the results of eight shift/xor opera-      */
+/*      tions for all combinations of data and CRC register values.       */
+/*                                                                        */
+/*      The values must be right-shifted by eight bits by the "updcrc"    */
+/*      logic; the shift must be unsigned (bring in zeroes).  On some     */
+/*      hardware you could probably optimize the shift in assembler by    */
+/*      using byte-swap instructions.                                     */
+/*      polynomial $edb88320                                              */
+/*                                                                        */
+/*  --------------------------------------------------------------------  */
+
+static unsigned long crc32_tab[] = {
+        0x00000000L, 0x77073096L, 0xee0e612cL, 0x990951baL, 0x076dc419L,
+        0x706af48fL, 0xe963a535L, 0x9e6495a3L, 0x0edb8832L, 0x79dcb8a4L,
+        0xe0d5e91eL, 0x97d2d988L, 0x09b64c2bL, 0x7eb17cbdL, 0xe7b82d07L,
+        0x90bf1d91L, 0x1db71064L, 0x6ab020f2L, 0xf3b97148L, 0x84be41deL,
+        0x1adad47dL, 0x6ddde4ebL, 0xf4d4b551L, 0x83d385c7L, 0x136c9856L,
+        0x646ba8c0L, 0xfd62f97aL, 0x8a65c9ecL, 0x14015c4fL, 0x63066cd9L,
+        0xfa0f3d63L, 0x8d080df5L, 0x3b6e20c8L, 0x4c69105eL, 0xd56041e4L,
+        0xa2677172L, 0x3c03e4d1L, 0x4b04d447L, 0xd20d85fdL, 0xa50ab56bL,
+        0x35b5a8faL, 0x42b2986cL, 0xdbbbc9d6L, 0xacbcf940L, 0x32d86ce3L,
+        0x45df5c75L, 0xdcd60dcfL, 0xabd13d59L, 0x26d930acL, 0x51de003aL,
+        0xc8d75180L, 0xbfd06116L, 0x21b4f4b5L, 0x56b3c423L, 0xcfba9599L,
+        0xb8bda50fL, 0x2802b89eL, 0x5f058808L, 0xc60cd9b2L, 0xb10be924L,
+        0x2f6f7c87L, 0x58684c11L, 0xc1611dabL, 0xb6662d3dL, 0x76dc4190L,
+        0x01db7106L, 0x98d220bcL, 0xefd5102aL, 0x71b18589L, 0x06b6b51fL,
+        0x9fbfe4a5L, 0xe8b8d433L, 0x7807c9a2L, 0x0f00f934L, 0x9609a88eL,
+        0xe10e9818L, 0x7f6a0dbbL, 0x086d3d2dL, 0x91646c97L, 0xe6635c01L,
+        0x6b6b51f4L, 0x1c6c6162L, 0x856530d8L, 0xf262004eL, 0x6c0695edL,
+        0x1b01a57bL, 0x8208f4c1L, 0xf50fc457L, 0x65b0d9c6L, 0x12b7e950L,
+        0x8bbeb8eaL, 0xfcb9887cL, 0x62dd1ddfL, 0x15da2d49L, 0x8cd37cf3L,
+        0xfbd44c65L, 0x4db26158L, 0x3ab551ceL, 0xa3bc0074L, 0xd4bb30e2L,
+        0x4adfa541L, 0x3dd895d7L, 0xa4d1c46dL, 0xd3d6f4fbL, 0x4369e96aL,
+        0x346ed9fcL, 0xad678846L, 0xda60b8d0L, 0x44042d73L, 0x33031de5L,
+        0xaa0a4c5fL, 0xdd0d7cc9L, 0x5005713cL, 0x270241aaL, 0xbe0b1010L,
+        0xc90c2086L, 0x5768b525L, 0x206f85b3L, 0xb966d409L, 0xce61e49fL,
+        0x5edef90eL, 0x29d9c998L, 0xb0d09822L, 0xc7d7a8b4L, 0x59b33d17L,
+        0x2eb40d81L, 0xb7bd5c3bL, 0xc0ba6cadL, 0xedb88320L, 0x9abfb3b6L,
+        0x03b6e20cL, 0x74b1d29aL, 0xead54739L, 0x9dd277afL, 0x04db2615L,
+        0x73dc1683L, 0xe3630b12L, 0x94643b84L, 0x0d6d6a3eL, 0x7a6a5aa8L,
+        0xe40ecf0bL, 0x9309ff9dL, 0x0a00ae27L, 0x7d079eb1L, 0xf00f9344L,
+        0x8708a3d2L, 0x1e01f268L, 0x6906c2feL, 0xf762575dL, 0x806567cbL,
+        0x196c3671L, 0x6e6b06e7L, 0xfed41b76L, 0x89d32be0L, 0x10da7a5aL,
+        0x67dd4accL, 0xf9b9df6fL, 0x8ebeeff9L, 0x17b7be43L, 0x60b08ed5L,
+        0xd6d6a3e8L, 0xa1d1937eL, 0x38d8c2c4L, 0x4fdff252L, 0xd1bb67f1L,
+        0xa6bc5767L, 0x3fb506ddL, 0x48b2364bL, 0xd80d2bdaL, 0xaf0a1b4cL,
+        0x36034af6L, 0x41047a60L, 0xdf60efc3L, 0xa867df55L, 0x316e8eefL,
+        0x4669be79L, 0xcb61b38cL, 0xbc66831aL, 0x256fd2a0L, 0x5268e236L,
+        0xcc0c7795L, 0xbb0b4703L, 0x220216b9L, 0x5505262fL, 0xc5ba3bbeL,
+        0xb2bd0b28L, 0x2bb45a92L, 0x5cb36a04L, 0xc2d7ffa7L, 0xb5d0cf31L,
+        0x2cd99e8bL, 0x5bdeae1dL, 0x9b64c2b0L, 0xec63f226L, 0x756aa39cL,
+        0x026d930aL, 0x9c0906a9L, 0xeb0e363fL, 0x72076785L, 0x05005713L,
+        0x95bf4a82L, 0xe2b87a14L, 0x7bb12baeL, 0x0cb61b38L, 0x92d28e9bL,
+        0xe5d5be0dL, 0x7cdcefb7L, 0x0bdbdf21L, 0x86d3d2d4L, 0xf1d4e242L,
+        0x68ddb3f8L, 0x1fda836eL, 0x81be16cdL, 0xf6b9265bL, 0x6fb077e1L,
+        0x18b74777L, 0x88085ae6L, 0xff0f6a70L, 0x66063bcaL, 0x11010b5cL,
+        0x8f659effL, 0xf862ae69L, 0x616bffd3L, 0x166ccf45L, 0xa00ae278L,
+        0xd70dd2eeL, 0x4e048354L, 0x3903b3c2L, 0xa7672661L, 0xd06016f7L,
+        0x4969474dL, 0x3e6e77dbL, 0xaed16a4aL, 0xd9d65adcL, 0x40df0b66L,
+        0x37d83bf0L, 0xa9bcae53L, 0xdebb9ec5L, 0x47b2cf7fL, 0x30b5ffe9L,
+        0xbdbdf21cL, 0xcabac28aL, 0x53b39330L, 0x24b4a3a6L, 0xbad03605L,
+        0xcdd70693L, 0x54de5729L, 0x23d967bfL, 0xb3667a2eL, 0xc4614ab8L,
+        0x5d681b02L, 0x2a6f2b94L, 0xb40bbe37L, 0xc30c8ea1L, 0x5a05df1bL,
+        0x2d02ef8dL
+};
+
+/* Return a 32-bit CRC of the contents of the buffer. */
+
+unsigned long crc32(const unsigned char *s, unsigned int len)
+{
+    unsigned int i;
+    unsigned long crc32val;
+
+    crc32val = 0;
+    for (i = 0;  i < len;  i ++)
+    {
+        crc32val =
+                crc32_tab[(crc32val ^ s[i]) & 0xff] ^
+                (crc32val >> 8);
+    }
+    return crc32val;
+}
+
+/*
+ * Hashing function for a string
+ */
+unsigned int hashmap_hash_int(hashmap_map * m, any_t inKey){
+
+    unsigned int key = inKey;
+
+    /* Robert Jenkins' 32 bit Mix Function */
+    key += (key << 12);
+    key ^= (key >> 22);
+    key += (key << 4);
+    key ^= (key >> 9);
+    key += (key << 10);
+    key ^= (key >> 2);
+    key += (key << 7);
+    key ^= (key >> 12);
+
+    /* Knuth's Multiplicative Method */
+    key = (key >> 3) * 2654435761;
+
+    return key % m->table_size;
+}
+
+/*
+ * Return the integer of the location in data
+ * to store the point to the item, or MAP_FULL.
+ */
+int hashmap_hash(map_t in, any_t key){
+    int curr;
+    int i;
+
+    /* Cast the hashmap */
+    hashmap_map* m = (hashmap_map *) in;
+
+    /* If full, return immediately */
+    if(m->size >= (m->table_size/2)) return MAP_FULL;
+
+    /* Find the best index */
+    curr = hashmap_hash_int(m, key);
+
+    /* Linear probing */
+    for(i = 0; i< MAX_CHAIN_LENGTH; i++){
+        if(m->data[curr].in_use == 0)
+            return curr;
+
+        if(m->data[curr].in_use == 1 && (m->data[curr].key == key))
+            return curr;
+
+        curr = (curr + 1) % m->table_size;
+    }
+
+    return MAP_FULL;
+}
+
+/*
+ * Doubles the size of the hashmap, and rehashes all the elements
+ */
+int hashmap_rehash(map_t in){
+    int i;
+    int old_size;
+    hashmap_element* curr;
+
+    /* Setup the new elements */
+    hashmap_map *m = (hashmap_map *) in;
+    hashmap_element* temp = (hashmap_element *)
+            calloc(2 * m->table_size, sizeof(hashmap_element));
+    if(!temp) return MAP_OMEM;
+
+    /* Update the array */
+    curr = m->data;
+    m->data = temp;
+
+    /* Update the size */
+    old_size = m->table_size;
+    m->table_size = 2 * m->table_size;
+    m->size = 0;
+
+    /* Rehash the elements */
+    for(i = 0; i < old_size; i++){
+        int status;
+
+        if (curr[i].in_use == 0)
+            continue;
+
+        status = hashmap_put(m, curr[i].key, curr[i].data);
+        if (status != MAP_OK)
+            return status;
+    }
+
+    free(curr);
+
+    return MAP_OK;
+}
+
+/*
+ * Add a pointer to the hashmap with some key
+ */
+int hashmap_put(map_t in, any_t key, any_t value){
+    int index;
+    hashmap_map* m;
+
+    /* Cast the hashmap */
+    m = (hashmap_map *) in;
+
+    /* Find a place to put our value */
+    index = hashmap_hash(in, key);
+    while(index == MAP_FULL){
+        if (hashmap_rehash(in) == MAP_OMEM) {
+            return MAP_OMEM;
+        }
+        index = hashmap_hash(in, key);
+    }
+
+    /* Set the data */
+    m->data[index].data = value;
+    m->data[index].key = key;
+    m->data[index].in_use = 1;
+    m->size++;
+
+    return MAP_OK;
+}
+
+/*
+ * Get your pointer out of the hashmap with a key
+ */
+any_t hashmap_get(map_t in, any_t key){
+    int curr;
+    int i;
+    hashmap_map* m;
+
+    /* Cast the hashmap */
+    m = (hashmap_map *) in;
+
+    /* Find data location */
+    curr = hashmap_hash_int(m, key);
+
+    /* Linear probing, if necessary */
+    for(i = 0; i<MAX_CHAIN_LENGTH; i++){
+
+        int in_use = m->data[curr].in_use;
+        if (in_use == 1){
+            if (m->data[curr].key == key){
+                return (m->data[curr].data);
+            }
+        }
+
+        curr = (curr + 1) % m->table_size;
+    }
+
+    /* Not found */
+    return NULL;
+}
+
+/*
+ * Remove an element with that key from the map
+ */
+int hashmap_remove(map_t in, any_t key){
+    int i;
+    int curr;
+    hashmap_map* m;
+
+    /* Cast the hashmap */
+    m = (hashmap_map *) in;
+
+    /* Find key */
+    curr = hashmap_hash_int(m, key);
+
+    /* Linear probing, if necessary */
+    for(i = 0; i<MAX_CHAIN_LENGTH; i++){
+
+        int in_use = m->data[curr].in_use;
+        if (in_use == 1){
+            if (m->data[curr].key == key){
+                /* Blank out the fields */
+                m->data[curr].in_use = 0;
+                m->data[curr].data = NULL;
+                m->data[curr].key = NULL;
+
+                /* Reduce the size */
+                m->size--;
+                return MAP_OK;
+            }
+        }
+        curr = (curr + 1) % m->table_size;
+    }
+
+    /* Data not found */
+    return MAP_MISSING;
+}
+
+/*
+ * Remove an element with that key from the map
+ */
+int hashmap_clear(map_t in){
+    int i;
+    hashmap_map* m;
+
+    /* Cast the hashmap */
+    m = (hashmap_map *) in;
+
+    /* Linear probing, if necessary */
+    for(i = 0; i<MAX_CHAIN_LENGTH; i++){
+        /* Blank out the fields */
+        m->data[i].in_use = 0;
+        m->data[i].data = NULL;
+        m->data[i].key = NULL;
+
+        /* Reduce the size */
+        m->size--;
+        return MAP_OK;
+    }
+
+    /* Data not found */
+    return MAP_MISSING;
+}
+
+any_t hashmap_get_index(map_t in, int index) {
+    hashmap_map* m;
+
+    /* Cast the hashmap */
+    m = (hashmap_map *) in;
+    return (m->data[index].data);
+}
+
+/* Deallocate the hashmap */
+void hashmap_free(map_t in){
+    hashmap_map* m = (hashmap_map*) in;
+    free(m->data);
+    free(m);
+}
+
+/* Return the length of the hashmap */
+int hashmap_length(map_t in){
+    hashmap_map* m = (hashmap_map *) in;
+    if(m != NULL) return m->size;
+    else return 0;
+}

--- a/hashmap.c
+++ b/hashmap.c
@@ -44,121 +44,13 @@ map_t hashmap_new() {
     return NULL;
 }
 
-/* The implementation here was originally done by Gary S. Brown.  I have
-   borrowed the tables directly, and made some minor changes to the
-   crc32-function (including changing the interface). //ylo */
+/* The implementation here was originally done by Gary S. Brown. It has been substantially
+ * simplified to usean any_t as the inKey instead of a char* //ylo */
 
 /* ============================================================= */
 /*  COPYRIGHT (C) 1986 Gary S. Brown.  You may use this program, or       */
 /*  code or tables extracted from it, as desired without restriction.     */
-/*                                                                        */
-/*  First, the polynomial itself and its table of feedback terms.  The    */
-/*  polynomial is                                                         */
-/*  X^32+X^26+X^23+X^22+X^16+X^12+X^11+X^10+X^8+X^7+X^5+X^4+X^2+X^1+X^0   */
-/*                                                                        */
-/*  Note that we take it "backwards" and put the highest-order term in    */
-/*  the lowest-order bit.  The X^32 term is "implied"; the LSB is the     */
-/*  X^31 term, etc.  The X^0 term (usually shown as "+1") results in      */
-/*  the MSB being 1.                                                      */
-/*                                                                        */
-/*  Note that the usual hardware shift register implementation, which     */
-/*  is what we're using (we're merely optimizing it by doing eight-bit    */
-/*  chunks at a time) shifts bits into the lowest-order term.  In our     */
-/*  implementation, that means shifting towards the right.  Why do we     */
-/*  do it this way?  Because the calculated CRC must be transmitted in    */
-/*  order from highest-order term to lowest-order term.  UARTs transmit   */
-/*  characters in order from LSB to MSB.  By storing the CRC this way,    */
-/*  we hand it to the UART in the order low-byte to high-byte; the UART   */
-/*  sends each low-bit to hight-bit; and the result is transmission bit   */
-/*  by bit from highest- to lowest-order term without requiring any bit   */
-/*  shuffling on our part.  Reception works similarly.                    */
-/*                                                                        */
-/*  The feedback terms table consists of 256, 32-bit entries.  Notes:     */
-/*                                                                        */
-/*      The table can be generated at runtime if desired; code to do so   */
-/*      is shown later.  It might not be obvious, but the feedback        */
-/*      terms simply represent the results of eight shift/xor opera-      */
-/*      tions for all combinations of data and CRC register values.       */
-/*                                                                        */
-/*      The values must be right-shifted by eight bits by the "updcrc"    */
-/*      logic; the shift must be unsigned (bring in zeroes).  On some     */
-/*      hardware you could probably optimize the shift in assembler by    */
-/*      using byte-swap instructions.                                     */
-/*      polynomial $edb88320                                              */
-/*                                                                        */
 /*  --------------------------------------------------------------------  */
-
-static unsigned long crc32_tab[] = {
-        0x00000000L, 0x77073096L, 0xee0e612cL, 0x990951baL, 0x076dc419L,
-        0x706af48fL, 0xe963a535L, 0x9e6495a3L, 0x0edb8832L, 0x79dcb8a4L,
-        0xe0d5e91eL, 0x97d2d988L, 0x09b64c2bL, 0x7eb17cbdL, 0xe7b82d07L,
-        0x90bf1d91L, 0x1db71064L, 0x6ab020f2L, 0xf3b97148L, 0x84be41deL,
-        0x1adad47dL, 0x6ddde4ebL, 0xf4d4b551L, 0x83d385c7L, 0x136c9856L,
-        0x646ba8c0L, 0xfd62f97aL, 0x8a65c9ecL, 0x14015c4fL, 0x63066cd9L,
-        0xfa0f3d63L, 0x8d080df5L, 0x3b6e20c8L, 0x4c69105eL, 0xd56041e4L,
-        0xa2677172L, 0x3c03e4d1L, 0x4b04d447L, 0xd20d85fdL, 0xa50ab56bL,
-        0x35b5a8faL, 0x42b2986cL, 0xdbbbc9d6L, 0xacbcf940L, 0x32d86ce3L,
-        0x45df5c75L, 0xdcd60dcfL, 0xabd13d59L, 0x26d930acL, 0x51de003aL,
-        0xc8d75180L, 0xbfd06116L, 0x21b4f4b5L, 0x56b3c423L, 0xcfba9599L,
-        0xb8bda50fL, 0x2802b89eL, 0x5f058808L, 0xc60cd9b2L, 0xb10be924L,
-        0x2f6f7c87L, 0x58684c11L, 0xc1611dabL, 0xb6662d3dL, 0x76dc4190L,
-        0x01db7106L, 0x98d220bcL, 0xefd5102aL, 0x71b18589L, 0x06b6b51fL,
-        0x9fbfe4a5L, 0xe8b8d433L, 0x7807c9a2L, 0x0f00f934L, 0x9609a88eL,
-        0xe10e9818L, 0x7f6a0dbbL, 0x086d3d2dL, 0x91646c97L, 0xe6635c01L,
-        0x6b6b51f4L, 0x1c6c6162L, 0x856530d8L, 0xf262004eL, 0x6c0695edL,
-        0x1b01a57bL, 0x8208f4c1L, 0xf50fc457L, 0x65b0d9c6L, 0x12b7e950L,
-        0x8bbeb8eaL, 0xfcb9887cL, 0x62dd1ddfL, 0x15da2d49L, 0x8cd37cf3L,
-        0xfbd44c65L, 0x4db26158L, 0x3ab551ceL, 0xa3bc0074L, 0xd4bb30e2L,
-        0x4adfa541L, 0x3dd895d7L, 0xa4d1c46dL, 0xd3d6f4fbL, 0x4369e96aL,
-        0x346ed9fcL, 0xad678846L, 0xda60b8d0L, 0x44042d73L, 0x33031de5L,
-        0xaa0a4c5fL, 0xdd0d7cc9L, 0x5005713cL, 0x270241aaL, 0xbe0b1010L,
-        0xc90c2086L, 0x5768b525L, 0x206f85b3L, 0xb966d409L, 0xce61e49fL,
-        0x5edef90eL, 0x29d9c998L, 0xb0d09822L, 0xc7d7a8b4L, 0x59b33d17L,
-        0x2eb40d81L, 0xb7bd5c3bL, 0xc0ba6cadL, 0xedb88320L, 0x9abfb3b6L,
-        0x03b6e20cL, 0x74b1d29aL, 0xead54739L, 0x9dd277afL, 0x04db2615L,
-        0x73dc1683L, 0xe3630b12L, 0x94643b84L, 0x0d6d6a3eL, 0x7a6a5aa8L,
-        0xe40ecf0bL, 0x9309ff9dL, 0x0a00ae27L, 0x7d079eb1L, 0xf00f9344L,
-        0x8708a3d2L, 0x1e01f268L, 0x6906c2feL, 0xf762575dL, 0x806567cbL,
-        0x196c3671L, 0x6e6b06e7L, 0xfed41b76L, 0x89d32be0L, 0x10da7a5aL,
-        0x67dd4accL, 0xf9b9df6fL, 0x8ebeeff9L, 0x17b7be43L, 0x60b08ed5L,
-        0xd6d6a3e8L, 0xa1d1937eL, 0x38d8c2c4L, 0x4fdff252L, 0xd1bb67f1L,
-        0xa6bc5767L, 0x3fb506ddL, 0x48b2364bL, 0xd80d2bdaL, 0xaf0a1b4cL,
-        0x36034af6L, 0x41047a60L, 0xdf60efc3L, 0xa867df55L, 0x316e8eefL,
-        0x4669be79L, 0xcb61b38cL, 0xbc66831aL, 0x256fd2a0L, 0x5268e236L,
-        0xcc0c7795L, 0xbb0b4703L, 0x220216b9L, 0x5505262fL, 0xc5ba3bbeL,
-        0xb2bd0b28L, 0x2bb45a92L, 0x5cb36a04L, 0xc2d7ffa7L, 0xb5d0cf31L,
-        0x2cd99e8bL, 0x5bdeae1dL, 0x9b64c2b0L, 0xec63f226L, 0x756aa39cL,
-        0x026d930aL, 0x9c0906a9L, 0xeb0e363fL, 0x72076785L, 0x05005713L,
-        0x95bf4a82L, 0xe2b87a14L, 0x7bb12baeL, 0x0cb61b38L, 0x92d28e9bL,
-        0xe5d5be0dL, 0x7cdcefb7L, 0x0bdbdf21L, 0x86d3d2d4L, 0xf1d4e242L,
-        0x68ddb3f8L, 0x1fda836eL, 0x81be16cdL, 0xf6b9265bL, 0x6fb077e1L,
-        0x18b74777L, 0x88085ae6L, 0xff0f6a70L, 0x66063bcaL, 0x11010b5cL,
-        0x8f659effL, 0xf862ae69L, 0x616bffd3L, 0x166ccf45L, 0xa00ae278L,
-        0xd70dd2eeL, 0x4e048354L, 0x3903b3c2L, 0xa7672661L, 0xd06016f7L,
-        0x4969474dL, 0x3e6e77dbL, 0xaed16a4aL, 0xd9d65adcL, 0x40df0b66L,
-        0x37d83bf0L, 0xa9bcae53L, 0xdebb9ec5L, 0x47b2cf7fL, 0x30b5ffe9L,
-        0xbdbdf21cL, 0xcabac28aL, 0x53b39330L, 0x24b4a3a6L, 0xbad03605L,
-        0xcdd70693L, 0x54de5729L, 0x23d967bfL, 0xb3667a2eL, 0xc4614ab8L,
-        0x5d681b02L, 0x2a6f2b94L, 0xb40bbe37L, 0xc30c8ea1L, 0x5a05df1bL,
-        0x2d02ef8dL
-};
-
-/* Return a 32-bit CRC of the contents of the buffer. */
-
-unsigned long crc32(const unsigned char *s, unsigned int len)
-{
-    unsigned int i;
-    unsigned long crc32val;
-
-    crc32val = 0;
-    for (i = 0;  i < len;  i ++)
-    {
-        crc32val =
-                crc32_tab[(crc32val ^ s[i]) & 0xff] ^
-                (crc32val >> 8);
-    }
-    return crc32val;
-}
 
 /*
  * Hashing function for a string

--- a/hashmap.h
+++ b/hashmap.h
@@ -3,8 +3,8 @@
  *
  * Originally by Elliot C Back - http://elliottback.com/wp/hashmap-implementation-in-c/
  *
- * Modified by Pete Warden to fix a serious performance problem, support strings as keys
- * and removed thread synchronization - http://petewarden.typepad.com
+ * Modified by Pete Warden to fix a serious performance problem, and removed thread 
+ * synchronization - http://petewarden.typepad.com
  */
 #ifndef __HASHMAP_H__
 #define __HASHMAP_H__

--- a/hashmap.h
+++ b/hashmap.h
@@ -1,0 +1,85 @@
+/*
+ * Generic hashmap manipulation functions
+ *
+ * Originally by Elliot C Back - http://elliottback.com/wp/hashmap-implementation-in-c/
+ *
+ * Modified by Pete Warden to fix a serious performance problem, support strings as keys
+ * and removed thread synchronization - http://petewarden.typepad.com
+ */
+#ifndef __HASHMAP_H__
+#define __HASHMAP_H__
+
+#define MAP_MISSING -3  /* No such element */
+#define MAP_FULL -2 	/* Hashmap is full */
+#define MAP_OMEM -1 	/* Out of Memory */
+#define MAP_OK 0 	/* OK */
+
+/*
+ * any_t is a pointer.  This allows you to put arbitrary structures in
+ * the hashmap.
+ */
+typedef void *any_t;
+
+/*
+ * PFany is a pointer to a function that can take two any_t arguments
+ * and return an integer. Returns status code..
+ */
+typedef int (*PFany)(any_t, any_t);
+
+/*
+ * map_t is a pointer to an internally maintained data structure.
+ * Clients of this package do not need to know how hashmaps are
+ * represented.  They see and manipulate only map_t's.
+ */
+typedef any_t map_t;
+
+/*
+ * Return an empty hashmap. Returns NULL if empty.
+*/
+extern map_t hashmap_new();
+
+/*
+ * Iteratively call f with argument (item, data) for
+ * each element data in the hashmap. The function must
+ * return a map status code. If it returns anything other
+ * than MAP_OK the traversal is terminated. f must
+ * not reenter any hashmap functions, or deadlock may arise.
+ */
+extern int hashmap_iterate(map_t in, PFany f, any_t item);
+
+/*
+ * Add an element to the hashmap. Return MAP_OK or MAP_OMEM.
+ */
+extern int hashmap_put(map_t in, any_t key, any_t value);
+
+/*
+ * Get an element from the hashmap. Return MAP_OK or MAP_MISSING.
+ */
+extern any_t hashmap_get(map_t in, any_t key);
+
+extern any_t hashmap_get_index(map_t in, int index);
+
+/*
+ * Remove an element from the hashmap. Return MAP_OK or MAP_MISSING.
+ */
+extern int hashmap_remove(map_t in, any_t key);
+
+extern int hashmap_clear(map_t in);
+
+/*
+ * Get any element. Return MAP_OK or MAP_MISSING.
+ * remove - should the element be removed from the hashmap
+ */
+extern int hashmap_get_one(map_t in, any_t *arg, int remove);
+
+/*
+ * Free the hashmap
+ */
+extern void hashmap_free(map_t in);
+
+/*
+ * Get the current size of a hashmap
+ */
+extern int hashmap_length(map_t in);
+
+#endif __HASHMAP_H__


### PR DESCRIPTION
Added hashmap, and modified BRSet to use kvp patterns instead of arrays/iteration for get/put/remove methods. This reduces get from O(n) to O(1). I kept the original BRSet class and method names so all changes could be isolated to this single class file, and reference to it didn't need to be changed.