### PR TITLE
start sync from specific block added

### DIFF
--- a/BRChainParams.h
+++ b/BRChainParams.h
@@ -66,7 +66,7 @@ static const char *BRTestNetDNSSeeds[] = {
 // blockchain checkpoints - these are also used as starting points for partial chain downloads, so they must be at
 // difficulty transition boundaries in order to verify the block difficulty at the immediately following transition
 static const BRCheckPoint BRMainNetCheckpoints[] = {
-        /*{       0, uint256("7497ea1b465eb39f1c8f507bc877078fe016d6fcb6dfad3a64c98dcc6e1e8496"), 1389388394, 0x1e0ffff0 },
+        {       0, uint256("7497ea1b465eb39f1c8f507bc877078fe016d6fcb6dfad3a64c98dcc6e1e8496"), 1389388394, 0x1e0ffff0 },
         {    5000, uint256("95753d284404118788a799ac754a3fdb5d817f5bd73a78697dfe40985c085596"), 1389701913, 0x1c32a753 },
         {   10000, uint256("12f90b8744f3b965e107ad9fd8b33ba6d95a91882fbc4b5f8588d70d494bed88"), 1389996580, 0x1c1557fc },
         {   12000, uint256("a1266acba91dc3d5737d9e8c6e21b7a91901f7f4c48082ce3d84dd394a13e415"), 1390115182, 0x1c0d748e },
@@ -85,7 +85,7 @@ static const BRCheckPoint BRMainNetCheckpoints[] = {
         { 1380000, uint256("00000000000001969b1e5836dd8bf6a001d96f4a16d336e09405b62b29feead6"), 1447731080, 0x1a02e03e },
         { 1435000, uint256("f78cc9c2791c8a23720e2efcdaf46584046ee5db8f050e21a3a15a13f5c68da0"), 1449312651, 0x1c1f3df6 },
         { 3000000, uint256("c9b034e634cb78f16385ba5cd166f91a5b448af84d6b20c0a924bc2f4409effd"), 1472667779, 0x1b24a10a },
-        { 4255555, uint256("23f72e760542bf021ec76d04231ad7cf80142069a79ba702028e074b726f86ef"), 1491329321, 0x1b26a4c3 },*/
+        { 4255555, uint256("23f72e760542bf021ec76d04231ad7cf80142069a79ba702028e074b726f86ef"), 1491329321, 0x1b26a4c3 },
         { 5712333, uint256("0000000000000003363ff6207a99a175e8b5adff71c77817a92f127fcefe936e"), 1513061829, 0x1924bd79 },
         { 5782400, uint256("b1005c34a3f4fbc0d99f2fe521490b63abd2ff2029fef80df72dd22ac2c735ec"), 1514109544, 0x1a5b24c0 },
         { 5822077, uint256("27d9687ef5f34d2b451c2c0d9c4a6612e7b4bbdc083d03bbdf2d2adbef08e5b1"), 1514700120, 0x1b023a6c },

--- a/BRPeer.c
+++ b/BRPeer.c
@@ -1420,7 +1420,7 @@ void BRPeerSendGetblocks(BRPeer *peer, const UInt256 locators[], size_t locators
     off += sizeof(UInt256);
     
     if (locatorsCount > 0) {
-        peer_log(peer, "calling getblocks with %zu locators: [%s,%s %s]", locatorsCount,
+        peer_log(peer, "calling getblocks with %zu locators: [%s, %s %s]", locatorsCount,
                  log_u256_hex_encode(locators[0]), (locatorsCount > 2 ? " ...," : ""),
                  (locatorsCount > 1 ? log_u256_hex_encode(locators[locatorsCount - 1]) : ""));
         BRPeerSendMessage(peer, msg, off, MSG_GETBLOCKS);

--- a/BRPeerManager.c
+++ b/BRPeerManager.c
@@ -1238,7 +1238,7 @@ static void _peerRelayedBlock(void *info, BRMerkleBlock *block)
     }
     else if (! prev) { // block is an orphan
         peer_log(peer, "relayed orphan block %s, previous %s, last block is %s, height %"PRIu32,
-                 u256hex(block->blockHash), u256hex(block->prevBlock), u256hex(manager->lastBlock->blockHash),
+                 log_u256_hex_encode(block->blockHash), log_u256_hex_encode(block->prevBlock), log_u256_hex_encode(manager->lastBlock->blockHash),
                  manager->lastBlock->height);
         
         if (block->timestamp + 7*24*60*60 < time(NULL)) { // ignore orphans older than one week ago
@@ -1534,7 +1534,14 @@ static void _dummyThreadCleanup(void *info)
 
 // returns a newly allocated BRPeerManager struct that must be freed by calling BRPeerManagerFree()
 BRPeerManager *BRPeerManagerNew(const BRChainParams *params, BRWallet *wallet, uint32_t earliestKeyTime,
-                                BRMerkleBlock *blocks[], size_t blocksCount, const BRPeer peers[], size_t peersCount)
+                                  BRMerkleBlock *blocks[], size_t blocksCount, const BRPeer peers[], size_t peersCount)
+{
+    return BRPeerManagerNewEx(params, wallet, earliestKeyTime, blocks, blocksCount, peers, peersCount, NULL);
+}
+
+// returns a newly allocated BRPeerManager struct that must be freed by calling BRPeerManagerFree()
+BRPeerManager *BRPeerManagerNewEx(const BRChainParams *params, BRWallet *wallet, uint32_t earliestKeyTime,
+                                BRMerkleBlock *blocks[], size_t blocksCount, const BRPeer peers[], size_t peersCount, BRMerkleBlock* startSyncFrom)
 {
     BRPeerManager *manager = calloc(1, sizeof(*manager));
     BRMerkleBlock orphan, *block = NULL;
@@ -1550,32 +1557,45 @@ BRPeerManager *BRPeerManagerNew(const BRChainParams *params, BRWallet *wallet, u
     manager->averageTxPerBlock = 1400;
     manager->maxConnectCount = PEER_MAX_CONNECTIONS;
     array_new(manager->peers, peersCount);
-    if (peers) array_add_array(manager->peers, peers, peersCount);
+    if (peers)
+        array_add_array(manager->peers, peers, peersCount);
     qsort(manager->peers, array_count(manager->peers), sizeof(*manager->peers), _peerTimestampCompare);
     array_new(manager->connectedPeers, PEER_MAX_CONNECTIONS);
+    
     manager->blocks = BRSetNew(BRMerkleBlockHash, BRMerkleBlockEq, blocksCount);
     manager->orphans = BRSetNew(_BRPrevBlockHash, _BRPrevBlockEq, blocksCount); // orphans are indexed by prevBlock
     manager->checkpoints = BRSetNew(_BRBlockHeightHash, _BRBlockHeightEq, 100); // checkpoints are indexed by height
 
+    if (startSyncFrom) {
+        manager->earliestKeyTime = startSyncFrom->timestamp;
+        BRSetAdd(manager->checkpoints, startSyncFrom);
+        BRSetAdd(manager->blocks, startSyncFrom);
+        manager->lastBlock = startSyncFrom;
+    }
+    
     for (size_t i = 0; i < manager->params->checkpointsCount; i++) {
         block = BRMerkleBlockNew();
         block->height = manager->params->checkpoints[i].height;
         block->blockHash = UInt256Reverse(manager->params->checkpoints[i].hash);
         block->timestamp = manager->params->checkpoints[i].timestamp;
         block->target = manager->params->checkpoints[i].target;
+        
         BRSetAdd(manager->checkpoints, block);
         BRSetAdd(manager->blocks, block);
-        if (i == 0 || block->timestamp + 7*24*60*60 < manager->earliestKeyTime) manager->lastBlock = block;
+        
+        if ((i == 0 && !startSyncFrom) || block->timestamp + 7*24*60*60 < manager->earliestKeyTime)
+            manager->lastBlock = block;
     }
-
+    
     block = NULL;
     
     for (size_t i = 0; blocks && i < blocksCount; i++) {
         assert(blocks[i]->height != BLOCK_UNKNOWN_HEIGHT); // height must be saved/restored along with serialized block
         BRSetAdd(manager->orphans, blocks[i]);
 
-        if ((blocks[i]->height % BLOCK_DIFFICULTY_INTERVAL) == 0 &&
-            (! block || blocks[i]->height > block->height)) block = blocks[i]; // find last transition block
+        // find last transition block
+        if (! block || blocks[i]->height > block->height)
+            block = blocks[i];
     }
     
     while (block) {
@@ -1586,6 +1606,12 @@ BRPeerManager *BRPeerManagerNew(const BRChainParams *params, BRWallet *wallet, u
         orphan.prevBlock = block->blockHash;
         block = BRSetGet(manager->orphans, &orphan);
     }
+    
+    if (startSyncFrom) {
+        manager->lastBlock = startSyncFrom;
+    }
+    
+    printf("[START HEIGHT]: %d\n", manager->lastBlock->height);
     
     array_new(manager->txRelays, 10);
     array_new(manager->txRequests, 10);
@@ -2000,11 +2026,31 @@ void BRPeerManagerFree(BRPeerManager *manager)
     free(manager);
 }
 
+/*
+ * The following two methods sync the blockchain beginning from startBlock.
+ *
+ * Usage: Create a custom merkle block and pass it to BPPeerManagerMainNetNewEx()
+ *     BRMerkleBlock* test = BRMerkleBlockNew();
+ *     test->blockHash = UInt256Reverse(uint256("7497ea1b465eb39f1c8f507bc877078fe016d6fcb6dfad3a64c98dcc6e1e8496"));
+ *     test->height = 0;
+ *     test->timestamp = 1389388394;
+ *     test->target = 0x1e0ffff0;
+ */
+
+BRPeerManager* BPPeerManagerMainNetNewEx(BRWallet *wallet, uint32_t earliestKeyTime, BRMerkleBlock *blocks[], size_t blocksCount, const BRPeer peers[], size_t peersCount, BRMerkleBlock* startBlock) {
+    return BRPeerManagerNewEx(&BRMainNetParams, wallet, earliestKeyTime, blocks, blocksCount, peers, peersCount, startBlock);
+}
+BRPeerManager* BPPeerManagerTestNetNewEx(BRWallet *wallet, uint32_t earliestKeyTime, BRMerkleBlock *blocks[], size_t blocksCount, const BRPeer peers[], size_t peersCount, BRMerkleBlock* startBlock) {
+    return BRPeerManagerNewEx(&BRTestNetParams, wallet, earliestKeyTime,blocks, blocksCount, peers, peersCount, startBlock);
+}
 
 // function to create Peermanager under for the mainnet directly
 BRPeerManager *BPPeerManagerMainNetNew(BRWallet *wallet, uint32_t earliestKeyTime,
 									   BRMerkleBlock *blocks[], size_t blocksCount, const BRPeer peers[], size_t peersCount) {
-	return BRPeerManagerNew(&BRMainNetParams, wallet, earliestKeyTime,blocks, blocksCount, peers,peersCount);
+
+
+    
+    return BRPeerManagerNew(&BRMainNetParams, wallet, earliestKeyTime, blocks, blocksCount, peers, peersCount);
 }
 
 // function to create Peermanager under for the testnet directly

--- a/BRPeerManager.h
+++ b/BRPeerManager.h
@@ -46,20 +46,19 @@ extern "C" {
 /* OPTIONS FOR CLEARING MEMORY */
 /*
 Remarks:
-The authors of the original breadwallet core ensure that the application
-contains at least 2016 blocks, until a difficulty transition block gets relayed.
-Since Digibyte makes use of DigiShield (or more specifically MultiShield), on each and
-every block there occurs a difficulty transition.
-
-We need to keep some blocks in memory in case of forks, to walk the chain backwards.
-To clear memory we have introduced a trigger value: CLEAR_MEM_BLOCKS_COUNT_TRIGGER.
-If the BRPeerManager instance contains more than CLEAR_MEM_BLOCKS_COUNT_TRIGGER blocks in 'blocks',
-we trigger the memory cleanup. The first CLEAR_MEM_BLOCKS_COUNT_TAIL_LEN blocks will be freed up.
-Note that we have to remove the tail, that is, we have to walk back the chain, until we reach the tail,
-then free up the remaining blocks.
-
-CLEAR_MEM_BLOCKS_COUNT_TAIL_LEN is at least the SAVE_BLOCK_COUNT
-    plus a reserve of CLEAR_MEM_BLOCKS_RESERVE_COUNT blocks.
+    The authors of the original breadwallet core ensure that the application
+    contains at least 2016 blocks, until a difficulty transition block gets relayed.
+    Since Digibyte makes use of DigiShield (or more specifically MultiShield), on each and
+    every block there occurs a difficulty transition.
+    We need to keep some blocks in memory in case of forks, to walk the chain backwards.
+    To clear memory we have introduced a trigger value: CLEAR_MEM_BLOCKS_COUNT_TRIGGER.
+    If the BRPeerManager instance contains more than CLEAR_MEM_BLOCKS_COUNT_TRIGGER blocks in 'blocks',
+    we trigger the memory cleanup. The first CLEAR_MEM_BLOCKS_COUNT_TAIL_LEN blocks will be freed up.
+    Note that we have to remove the tail, that is, we have to walk back the chain, until we reach the tail,
+    then free up the remaining blocks.
+ 
+    CLEAR_MEM_BLOCKS_COUNT_TAIL_LEN is at least the SAVE_BLOCK_COUNT
+        plus a reserve of CLEAR_MEM_BLOCKS_RESERVE_COUNT blocks.
 */
 #define CLEAR_MEM_BLOCKS_COUNT_TRIGGER 5000
 #define CLEAR_MEM_BLOCKS_RESERVE_COUNT 500


### PR DESCRIPTION
BPPeerManagerMainNetNewEx adds the possibility to create an instance of BRPeerManager using a custom sync start block.

You can create this block as follows:

BRMerkleBlock* test = BRMerkleBlockNew();
test->blockHash = UInt256Reverse(uint256("7497ea1b465eb39f1c8f507bc877078fe016d6fcb6dfad3a64c98dcc6e1e8496"));
test->height = 0;
test->timestamp = 1389388394;
test->target = 0x1e0ffff0;